### PR TITLE
allow keywords parameters to be passed to requests API

### DIFF
--- a/crowdin_api/requester.py
+++ b/crowdin_api/requester.py
@@ -88,6 +88,7 @@ class APIRequester:
         headers: Optional[Dict] = None,
         request_data: Optional[Dict] = None,
         file: IO = None,
+        **kwargs
     ):
 
         if file and request_data:
@@ -109,6 +110,7 @@ class APIRequester:
             headers=headers,
             data=request_data,
             timeout=self._timeout,
+            **kwargs
         )
 
         status_code = result.status_code
@@ -134,6 +136,7 @@ class APIRequester:
         headers=None,
         request_data=None,
         file: IO = None,
+        **kwargs
     ):
         num_retries = 0
 
@@ -146,6 +149,7 @@ class APIRequester:
                     headers=headers,
                     request_data=request_data,
                     file=file,
+                    **kwargs
                 )
             except APIException as err:
                 num_retries += 1

--- a/crowdin_api/tests/test_requester.py
+++ b/crowdin_api/tests/test_requester.py
@@ -177,3 +177,15 @@ class TestAPIRequester:
     def test__clear_data(self, in_data, out_data, base_absolut_url):
         requester = APIRequester(base_url=base_absolut_url)
         assert requester._clear_data(in_data) == out_data
+
+    @mock.patch("crowdin_api.requester.APIRequester.request")
+    @pytest.mark.parametrize('kwargs', (
+            {"k_1": "v_1"},
+            {"k_2": "v_2",
+             "k_3": "v_3"},
+    ))
+    def test_kwargs_in_requester(self, m_request, base_absolut_url, kwargs):
+        m_request.return_value = "response"
+        _requester = APIRequester(base_url=base_absolut_url)
+        _requester.request('get', 'test', **kwargs)
+        m_request.assert_called_once_with('get', 'test', **kwargs)


### PR DESCRIPTION
At the moment, there is no way to pass arguments to the `requests` package, for example `verify` or `proxies`. This pull request allows the user to pass such parameters over the crowdin client.