### PR TITLE
Add typing-extensions as a requirement if Python version is < 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     license="MIT",
     install_requires=[
         "requests>=2.25.1",
+        "typing-extensions; python_version < '3.8.0'",
     ],
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
Fixes #13.