### PR TITLE
Fix Assign/unassign label from strings paths

### DIFF
--- a/crowdin_api/api_resources/labels/resource.py
+++ b/crowdin_api/api_resources/labels/resource.py
@@ -103,7 +103,7 @@ class LabelsResource(BaseResource):
         return self.requester.request(
             method="post",
             request_data={"stringIds": stringIds},
-            path=self.get_labels_path(projectId=projectId, labelId=labelId),
+            path=f"{self.get_labels_path(projectId=projectId, labelId=labelId)}/strings",
         )
 
     def unassign_label_from_strings(self, projectId: int, labelId: int, stringIds: Iterable[int]):
@@ -117,5 +117,5 @@ class LabelsResource(BaseResource):
         return self.requester.request(
             method="delete",
             params={"stringIds": ",".join(str(stringId) for stringId in stringIds)},
-            path=self.get_labels_path(projectId=projectId, labelId=labelId),
+            path=f"{self.get_labels_path(projectId=projectId, labelId=labelId)}/strings",
         )

--- a/crowdin_api/api_resources/labels/tests/test_labels_resources.py
+++ b/crowdin_api/api_resources/labels/tests/test_labels_resources.py
@@ -99,7 +99,7 @@ class TestLabelsResource:
         m_request.assert_called_once_with(
             request_data={"stringIds": [1, 2]},
             method="post",
-            path=resource.get_labels_path(projectId=1, labelId=2),
+            path=f"{resource.get_labels_path(projectId=1, labelId=2)}/strings",
         )
 
     @mock.patch("crowdin_api.requester.APIRequester.request")
@@ -114,5 +114,5 @@ class TestLabelsResource:
         m_request.assert_called_once_with(
             params={"stringIds": "1,2"},
             method="delete",
-            path=resource.get_labels_path(projectId=1, labelId=2),
+            path=f"{resource.get_labels_path(projectId=1, labelId=2)}/strings",
         )


### PR DESCRIPTION
Fixed paths in labels.assign/unassign label from strings methods to include the "/strings" suffix