### PR TITLE
Fix sends "null" in GET request body

### DIFF
--- a/crowdin_api/requester.py
+++ b/crowdin_api/requester.py
@@ -114,7 +114,7 @@ class APIRequester:
             file_mime_type = mimetypes.MimeTypes().guess_type(file.name)[0]
             headers["Content-Type"] = file_mime_type or self.default_file_content_type
             headers["Crowdin-API-FileName"] = os.path.basename(file.name)
-        else:
+        elif request_data is not None:
             request_data = dumps(self._clear_data(request_data))
 
         kwargs = {**self._extended_params, **kwargs}

--- a/crowdin_api/tests/test_requester.py
+++ b/crowdin_api/tests/test_requester.py
@@ -105,7 +105,7 @@ class TestAPIRequester:
             urljoin(base_absolut_url, path),
             params={},
             headers=None,
-            data="null",
+            data=None,
             timeout=80,
             **expected_result,
         )


### PR DESCRIPTION
Closes https://github.com/crowdin/crowdin-api-client-python/issues/84

Since 2023-05-30, crowdin API responses with error on any GET request (like. `list_files` or `list_projects`)
```
crowdin_api.exceptions.ValidationError: ValidationError: http_status=400, request_id=None, detail: None, context=b'{"error":{"message":"Incorrect json in request body. No error","code":400}}'
```
The problem is what we send "null" string in body on every GET request, caused by this code

https://github.com/crowdin/crowdin-api-client-python/blob/81e43ef9139b8acbe7c2d2b6e0c915927e4e0e7b/crowdin_api/requester.py#L118

Propose is to change with logic -- if method `request()` called without request_data, we sends no body at all. It correlates with API documentation (for example https://developer.crowdin.com/api/v2/#operation/api.projects.files.getMany), there is no specified body parameter.