### PR TITLE
fix(source_strings): add branch id parameter to add_string

### DIFF
--- a/crowdin_api/api_resources/source_strings/resource.py
+++ b/crowdin_api/api_resources/source_strings/resource.py
@@ -79,6 +79,7 @@ class SourceStringsResource(BaseResource):
         isHidden: Optional[bool] = None,
         maxLength: Optional[int] = None,
         labelIds: Optional[Iterable[int]] = None,
+        branchId: Optional[int] = None
     ):
         """
         Add String.
@@ -100,6 +101,7 @@ class SourceStringsResource(BaseResource):
                 "isHidden": isHidden,
                 "maxLength": maxLength,
                 "labelIds": labelIds,
+                "branchId": branchId
             },
         )
 

--- a/crowdin_api/api_resources/source_strings/tests/test_source_strings_resources.py
+++ b/crowdin_api/api_resources/source_strings/tests/test_source_strings_resources.py
@@ -106,6 +106,7 @@ class TestSourceFilesResource:
                     "isHidden": None,
                     "maxLength": None,
                     "labelIds": None,
+                    "branchId": None
                 },
             ),
             (
@@ -117,6 +118,7 @@ class TestSourceFilesResource:
                     "isHidden": True,
                     "maxLength": 2,
                     "labelIds": [1, 2, 3],
+                    "branchId": None
                 },
                 {
                     "text": "text",
@@ -126,6 +128,7 @@ class TestSourceFilesResource:
                     "isHidden": True,
                     "maxLength": 2,
                     "labelIds": [1, 2, 3],
+                    "branchId": None
                 },
             ),
         ),


### PR DESCRIPTION
The add_string method is missing the option to add a branch ID which is required when uploading strings to a string based project in Crowdin.