### PR TITLE
fix(api-requestor): bind custom values for max_retry and retry_delay

### DIFF
--- a/crowdin_api/client.py
+++ b/crowdin_api/client.py
@@ -86,6 +86,8 @@ class CrowdinClient:
             self._api_requestor = self.API_REQUESTER_CLASS(
                 base_url=self.url,
                 timeout=self.TIMEOUT,
+                retry_delay=self.RETRY_DELAY,
+                max_retries=self.MAX_RETRIES,
                 default_headers=self.get_default_headers(),
                 extended_params=self.EXTENDED_REQUEST_PARAMS
             )


### PR DESCRIPTION
👋 I found a small issue while sending translations via the api this afternoon

## Changes

- Bind `MAX_RETRY` + `RETRY_DELAY` to the api requestor
- Update default test
- Add a test with custom values


My current config:

```python
        return CrowdinClient(
            organization=self.organization, token=self.token, timeout=600, retry_delay=10
```

### Before

```sh
INFO:[requester.py] Initiating retry 1 for request post projects/xxx/translations after sleeping 0.1 seconds.
```

It doesn't use our custom values cf:
```sh
retry_delay=0.1 timeout=600 max_retries=5
```


### After

It takes the values we specified cf:
```sh
retry_delay=10 timeout=600 max_retries=5
```
