### PR TITLE
fix(translation_status): Fix list_qa_check_issues endpoint URL

### DIFF
--- a/crowdin_api/api_resources/translation_status/resource.py
+++ b/crowdin_api/api_resources/translation_status/resource.py
@@ -161,6 +161,6 @@ class TranslationStatusResource(BaseResource):
 
         return self._get_entire_data(
             method="get",
-            path=f"projects/{projectId}/languages/progress",
+            path=f"projects/{projectId}/qa-checks",
             params=params,
         )

--- a/crowdin_api/api_resources/translation_status/tests/test_translation_status_resources.py
+++ b/crowdin_api/api_resources/translation_status/tests/test_translation_status_resources.py
@@ -121,5 +121,5 @@ class TestTranslationStatusResource:
         resource = self.get_resource(base_absolut_url)
         assert resource.list_qa_check_issues(projectId=1, **in_params) == "response"
         m_request.assert_called_once_with(
-            method="get", path="projects/1/languages/progress", params=request_params
+            method="get", path="projects/1/qa-checks", params=request_params
         )


### PR DESCRIPTION
This PR fixes the endpoint URL in the `list_qa_check_issues()` method.

I guess that the code was originally copy-pasted from the `get_project_progress()` method, but the URL wasn't updated.
The endpoint in the JS client library is [here](https://github.com/crowdin/crowdin-api-client-js/blob/master/src/translationStatus/index.ts#L234).