### PR TITLE
feat: add addToTm parameter support for Upload Translation API

### DIFF
--- a/crowdin_api/api_resources/translations/resource.py
+++ b/crowdin_api/api_resources/translations/resource.py
@@ -327,33 +327,9 @@ class TranslationsResource(BaseResource):
         autoApproveImported: Optional[bool] = None,
         translateHidden: Optional[bool] = None,
         addToTm: Optional[bool] = None,
-    ) -> dict:
+    ):
         """
         Upload Translations.
-
-        Parameters
-        ----------
-        languageId: str
-            Language ID.
-        storageId: int
-            Storage ID.
-        fileId: int
-            File ID for import.
-        projectId: Optional[int]
-            Project ID.
-        importEqSuggestions: Optional[bool]
-            Define whether to add equal translations.
-        autoApproveImported: Optional[bool]
-            Mark uploaded translations as approved.
-        translateHidden: Optional[bool]
-            Allow translations upload to hidden source strings.
-        addToTm: Optional[bool]
-            Define whether to add translation to TM. Default: true
-
-        Returns
-        -------
-        dict
-            Upload Translation response from the API
 
         Link to documentation:
         https://developer.crowdin.com/api/v2/#operation/api.projects.translations.postOnLanguage

--- a/crowdin_api/api_resources/translations/resource.py
+++ b/crowdin_api/api_resources/translations/resource.py
@@ -5,6 +5,7 @@ from crowdin_api.api_resources.enums import ExportProjectTranslationFormat
 from crowdin_api.api_resources.translations.types import (
     FallbackLanguages,
     EditPreTranslationScheme,
+    UploadTranslationRequest,
 )
 from crowdin_api.api_resources.translations.enums import (
     CharTransformation,
@@ -317,34 +318,61 @@ class TranslationsResource(BaseResource):
         )
 
     def upload_translation(
-        self,
-        languageId: str,
-        storageId: int,
-        fileId: int,
-        projectId: Optional[int] = None,
-        importEqSuggestions: Optional[bool] = None,
-        autoApproveImported: Optional[bool] = None,
-        translateHidden: Optional[bool] = None,
-    ):
+    self,
+    languageId: str,
+    storageId: int,
+    fileId: int,
+    projectId: Optional[int] = None,
+    importEqSuggestions: Optional[bool] = None,
+    autoApproveImported: Optional[bool] = None,
+    translateHidden: Optional[bool] = None,
+    addToTm: Optional[bool] = None,
+) -> dict:
         """
         Upload Translations.
+
+        Parameters
+        ----------
+        languageId: str
+            Language ID.
+        storageId: int
+            Storage ID.
+        fileId: int
+            File ID for import.
+        projectId: Optional[int]
+            Project ID.
+        importEqSuggestions: Optional[bool]
+            Define whether to add equal translations.
+        autoApproveImported: Optional[bool]
+            Mark uploaded translations as approved.
+        translateHidden: Optional[bool]
+            Allow translations upload to hidden source strings.
+        addToTm: Optional[bool]
+            Define whether to add translation to TM. Default: true
+
+        Returns
+        -------
+        dict
+            Upload Translation response from the API
 
         Link to documentation:
         https://developer.crowdin.com/api/v2/#operation/api.projects.translations.postOnLanguage
         """
-
         projectId = projectId or self.get_project_id()
+
+        request_data: UploadTranslationRequest = {
+            "storageId": storageId,
+            "fileId": fileId,
+            "importEqSuggestions": importEqSuggestions,
+            "autoApproveImported": autoApproveImported,
+            "translateHidden": translateHidden,
+            "addToTm": addToTm,
+        }
 
         return self.requester.request(
             method="post",
             path=f"projects/{projectId}/translations/{languageId}",
-            request_data={
-                "storageId": storageId,
-                "fileId": fileId,
-                "importEqSuggestions": importEqSuggestions,
-                "autoApproveImported": autoApproveImported,
-                "translateHidden": translateHidden,
-            },
+            request_data=request_data,
         )
 
     def download_project_translations(

--- a/crowdin_api/api_resources/translations/resource.py
+++ b/crowdin_api/api_resources/translations/resource.py
@@ -319,7 +319,7 @@ class TranslationsResource(BaseResource):
 
     def upload_translation(
         self,
-        languageId: str, 
+        languageId: str,
         storageId: int,
         fileId: int,
         projectId: Optional[int] = None,

--- a/crowdin_api/api_resources/translations/resource.py
+++ b/crowdin_api/api_resources/translations/resource.py
@@ -318,16 +318,16 @@ class TranslationsResource(BaseResource):
         )
 
     def upload_translation(
-    self,
-    languageId: str,
-    storageId: int,
-    fileId: int,
-    projectId: Optional[int] = None,
-    importEqSuggestions: Optional[bool] = None,
-    autoApproveImported: Optional[bool] = None,
-    translateHidden: Optional[bool] = None,
-    addToTm: Optional[bool] = None,
-) -> dict:
+        self,
+        languageId: str, 
+        storageId: int,
+        fileId: int,
+        projectId: Optional[int] = None,
+        importEqSuggestions: Optional[bool] = None,
+        autoApproveImported: Optional[bool] = None,
+        translateHidden: Optional[bool] = None,
+        addToTm: Optional[bool] = None,
+    ) -> dict:
         """
         Upload Translations.
 

--- a/crowdin_api/api_resources/translations/tests/test_translations_resources.py
+++ b/crowdin_api/api_resources/translations/tests/test_translations_resources.py
@@ -309,89 +309,89 @@ class TestTranslationsResource:
         m_build_project_translation.assert_called_once_with(projectId=1, request_data=request_data)
 
     @pytest.mark.parametrize(
-       "in_params, request_data",
-       (
-           (
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-               },
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "importEqSuggestions": None,
-                   "autoApproveImported": None,
-                   "translateHidden": None, 
-                   "addToTm": None,
-               },
-           ),
-           (
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "importEqSuggestions": False,
-                   "autoApproveImported": False,
-                   "translateHidden": False,
-                   "addToTm": False,
-               },
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "importEqSuggestions": False,
-                   "autoApproveImported": False,
-                   "translateHidden": False,
-                   "addToTm": False,
-               },
-           ),
-           (
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "importEqSuggestions": True,
-                   "autoApproveImported": True,
-                   "translateHidden": True,
-                   "addToTm": True,
-               },
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "importEqSuggestions": True,
-                   "autoApproveImported": True,
-                   "translateHidden": True,
-                   "addToTm": True,
-               },
-           ),
-           (
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "addToTm": False,
-               },
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "importEqSuggestions": None,
-                   "autoApproveImported": None,
-                   "translateHidden": None,
-                   "addToTm": False,
-               },
-           ),
-           (
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "addToTm": True,
-               },
-               {
-                   "storageId": 1,
-                   "fileId": 2,
-                   "importEqSuggestions": None,
-                   "autoApproveImported": None,
-                   "translateHidden": None,
-                   "addToTm": True,
-               },
-           ),
-       ),
+        "in_params, request_data",
+        (
+            (
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                },
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "importEqSuggestions": None,
+                    "autoApproveImported": None,
+                    "translateHidden": None,
+                    "addToTm": None,
+                },
+            ),
+            (
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "importEqSuggestions": False,
+                    "autoApproveImported": False,
+                    "translateHidden": False,
+                    "addToTm": False,
+                },
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "importEqSuggestions": False,
+                    "autoApproveImported": False,
+                    "translateHidden": False,
+                    "addToTm": False,
+                },
+            ),
+            (
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "importEqSuggestions": True,
+                    "autoApproveImported": True,
+                    "translateHidden": True,
+                    "addToTm": True,
+                },
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "importEqSuggestions": True,
+                    "autoApproveImported": True,
+                    "translateHidden": True,
+                    "addToTm": True,
+                },
+            ),
+            (
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "addToTm": False,
+                },
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "importEqSuggestions": None,
+                    "autoApproveImported": None,
+                    "translateHidden": None,
+                    "addToTm": False,
+                },
+            ),
+            (
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "addToTm": True,
+                },
+                {
+                    "storageId": 1,
+                    "fileId": 2,
+                    "importEqSuggestions": None,
+                    "autoApproveImported": None,
+                    "translateHidden": None,
+                    "addToTm": True,
+                },
+            ),
+        ),
     )
     @mock.patch("crowdin_api.requester.APIRequester.request")
     def test_upload_translation(self, m_request, in_params, request_data, base_absolut_url):

--- a/crowdin_api/api_resources/translations/tests/test_translations_resources.py
+++ b/crowdin_api/api_resources/translations/tests/test_translations_resources.py
@@ -309,38 +309,89 @@ class TestTranslationsResource:
         m_build_project_translation.assert_called_once_with(projectId=1, request_data=request_data)
 
     @pytest.mark.parametrize(
-        "in_params, request_data",
+    "in_params, request_data",
+    (
         (
-            (
-                {
-                    "storageId": 1,
-                    "fileId": 2,
-                },
-                {
-                    "storageId": 1,
-                    "fileId": 2,
-                    "importEqSuggestions": None,
-                    "autoApproveImported": None,
-                    "translateHidden": None,
-                },
-            ),
-            (
-                {
-                    "storageId": 1,
-                    "fileId": 2,
-                    "importEqSuggestions": False,
-                    "autoApproveImported": False,
-                    "translateHidden": False,
-                },
-                {
-                    "storageId": 1,
-                    "fileId": 2,
-                    "importEqSuggestions": False,
-                    "autoApproveImported": False,
-                    "translateHidden": False,
-                },
-            ),
+            {
+                "storageId": 1,
+                "fileId": 2,
+            },
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "importEqSuggestions": None,
+                "autoApproveImported": None, 
+                "translateHidden": None,
+                "addToTm": None,
+            },
         ),
+        (
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "importEqSuggestions": False,
+                "autoApproveImported": False,
+                "translateHidden": False,
+                "addToTm": False,
+            },
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "importEqSuggestions": False,
+                "autoApproveImported": False,
+                "translateHidden": False,
+                "addToTm": False,
+            },
+        ),
+        (
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "importEqSuggestions": True,
+                "autoApproveImported": True,
+                "translateHidden": True,
+                "addToTm": True,
+            },
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "importEqSuggestions": True,
+                "autoApproveImported": True,
+                "translateHidden": True,
+                "addToTm": True,
+            },
+        ),
+        (
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "addToTm": False,
+            },
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "importEqSuggestions": None,
+                "autoApproveImported": None,
+                "translateHidden": None,
+                "addToTm": False,
+            },
+        ),
+        (
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "addToTm": True,
+            },
+            {
+                "storageId": 1,
+                "fileId": 2,
+                "importEqSuggestions": None,
+                "autoApproveImported": None,
+                "translateHidden": None,
+                "addToTm": True,
+            },
+        ),
+    ),
     )
     @mock.patch("crowdin_api.requester.APIRequester.request")
     def test_upload_translation(self, m_request, in_params, request_data, base_absolut_url):

--- a/crowdin_api/api_resources/translations/tests/test_translations_resources.py
+++ b/crowdin_api/api_resources/translations/tests/test_translations_resources.py
@@ -309,89 +309,89 @@ class TestTranslationsResource:
         m_build_project_translation.assert_called_once_with(projectId=1, request_data=request_data)
 
     @pytest.mark.parametrize(
-    "in_params, request_data",
-    (
-        (
-            {
-                "storageId": 1,
-                "fileId": 2,
-            },
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "importEqSuggestions": None,
-                "autoApproveImported": None, 
-                "translateHidden": None,
-                "addToTm": None,
-            },
-        ),
-        (
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "importEqSuggestions": False,
-                "autoApproveImported": False,
-                "translateHidden": False,
-                "addToTm": False,
-            },
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "importEqSuggestions": False,
-                "autoApproveImported": False,
-                "translateHidden": False,
-                "addToTm": False,
-            },
-        ),
-        (
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "importEqSuggestions": True,
-                "autoApproveImported": True,
-                "translateHidden": True,
-                "addToTm": True,
-            },
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "importEqSuggestions": True,
-                "autoApproveImported": True,
-                "translateHidden": True,
-                "addToTm": True,
-            },
-        ),
-        (
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "addToTm": False,
-            },
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "importEqSuggestions": None,
-                "autoApproveImported": None,
-                "translateHidden": None,
-                "addToTm": False,
-            },
-        ),
-        (
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "addToTm": True,
-            },
-            {
-                "storageId": 1,
-                "fileId": 2,
-                "importEqSuggestions": None,
-                "autoApproveImported": None,
-                "translateHidden": None,
-                "addToTm": True,
-            },
-        ),
-    ),
+       "in_params, request_data",
+       (
+           (
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+               },
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "importEqSuggestions": None,
+                   "autoApproveImported": None,
+                   "translateHidden": None, 
+                   "addToTm": None,
+               },
+           ),
+           (
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "importEqSuggestions": False,
+                   "autoApproveImported": False,
+                   "translateHidden": False,
+                   "addToTm": False,
+               },
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "importEqSuggestions": False,
+                   "autoApproveImported": False,
+                   "translateHidden": False,
+                   "addToTm": False,
+               },
+           ),
+           (
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "importEqSuggestions": True,
+                   "autoApproveImported": True,
+                   "translateHidden": True,
+                   "addToTm": True,
+               },
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "importEqSuggestions": True,
+                   "autoApproveImported": True,
+                   "translateHidden": True,
+                   "addToTm": True,
+               },
+           ),
+           (
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "addToTm": False,
+               },
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "importEqSuggestions": None,
+                   "autoApproveImported": None,
+                   "translateHidden": None,
+                   "addToTm": False,
+               },
+           ),
+           (
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "addToTm": True,
+               },
+               {
+                   "storageId": 1,
+                   "fileId": 2,
+                   "importEqSuggestions": None,
+                   "autoApproveImported": None,
+                   "translateHidden": None,
+                   "addToTm": True,
+               },
+           ),
+       ),
     )
     @mock.patch("crowdin_api.requester.APIRequester.request")
     def test_upload_translation(self, m_request, in_params, request_data, base_absolut_url):

--- a/crowdin_api/api_resources/translations/types.py
+++ b/crowdin_api/api_resources/translations/types.py
@@ -1,7 +1,5 @@
-from typing import Iterable, Optional 
-
+from typing import Iterable, Optional
 from crowdin_api.typing import TypedDict
-
 from crowdin_api.api_resources.translations.enums import PreTranslationEditOperation
 
 

--- a/crowdin_api/api_resources/translations/types.py
+++ b/crowdin_api/api_resources/translations/types.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterable, Optional 
 
 from crowdin_api.typing import TypedDict
 
@@ -13,3 +13,12 @@ class EditPreTranslationScheme(TypedDict):
     op: PreTranslationEditOperation
     path: str
     value: str
+
+
+class UploadTranslationRequest(TypedDict):
+    storageId: int
+    fileId: int
+    importEqSuggestions: Optional[bool]
+    autoApproveImported: Optional[bool]
+    translateHidden: Optional[bool]
+    addToTm: Optional[bool]


### PR DESCRIPTION
The support for addToTm parameter has been added to upload_translation method:
- Defined addToTm in UploadTranslationRequest type
- Added addToTm as optional boolean parameter in upload_translation
- Added comprehensive test cases covering all possible scenarios

Default value (true) is handled by the API as specified in: https://developer.crowdin.com/api/v2/#operation/api.projects.translations.postOnLanguage

Closes #183