### PR TITLE
feat(api): Add Pre-Translate Accuracy Report

### DIFF
--- a/crowdin_api/api_resources/reports/enums.py
+++ b/crowdin_api/api_resources/reports/enums.py
@@ -14,7 +14,7 @@ class ScopeType(Enum):
 
 
 class ReportName(Enum):
-    PRE_TRANSLATE_EFFICIENCY = "pre-translate-efficiency"
+    PRE_TRANSLATE_ACCURACY = "pre-translate-accuracy"
     COSTS_ESTIMATION = "costs-estimation"
     TRANSLATION_COSTS = "translation-costs"
     TOP_MEMBERS = "top-members"

--- a/crowdin_api/api_resources/reports/enums.py
+++ b/crowdin_api/api_resources/reports/enums.py
@@ -14,6 +14,7 @@ class ScopeType(Enum):
 
 
 class ReportName(Enum):
+    PRE_TRANSLATE_EFFICIENCY = "pre-translate-efficiency"
     COSTS_ESTIMATION = "costs-estimation"
     TRANSLATION_COSTS = "translation-costs"
     TOP_MEMBERS = "top-members"

--- a/crowdin_api/api_resources/reports/resource.py
+++ b/crowdin_api/api_resources/reports/resource.py
@@ -160,6 +160,76 @@ class BaseReportsResource(BaseResource):
             },
         )
 
+    def generate_pre_translate_efficiency_general_report(
+        self,
+        projectId: Optional[int] = None,
+        unit: Optional[Unit] = None,
+        format: Optional[Format] = None,
+        postEditingCategories: Optional[Iterable[str]] = None,
+        languageId: Optional[str] = None,
+        dateFrom: Optional[datetime] = None,
+        dateTo: Optional[datetime] = None,
+    ):
+        """
+        Generate Report.
+
+        Link to documentation:
+        https://developer.crowdin.com/api/v2/#operation/api.projects.reports.post
+
+        Link to documentation for enterprise:
+        https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.reports.post
+        """
+
+        projectId = projectId or self.get_project_id()
+
+        return self.generate_report(
+            projectId=projectId,
+            request_data={
+                "name": "pre-translate-efficiency",
+                "schema": {
+                    "unit": unit,
+                    "format": format,
+                    "postEditingCategories": postEditingCategories,
+                    "languageId": languageId,
+                    "dateFrom": dateFrom,
+                    "dateTo": dateTo,
+                },
+            },
+        )
+
+    def generate_pre_translate_efficiency_by_task_report(
+        self,
+        projectId: Optional[int] = None,
+        unit: Optional[Unit] = None,
+        format: Optional[Format] = None,
+        postEditingCategories: Optional[Iterable[str]] = None,
+        taskId: Optional[int] = None,
+    ):
+        """
+        Generate Report.
+
+        Link to documentation:
+        https://developer.crowdin.com/api/v2/#operation/api.projects.reports.post
+
+        Link to documentation for enterprise:
+        https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.reports.post
+        """
+
+        projectId = projectId or self.get_project_id()
+
+        return self.generate_report(
+            projectId=projectId,
+            request_data={
+                "name": "pre-translate-efficiency",
+                "schema": {
+                    "unit": unit,
+                    "format": format,
+                    "postEditingCategories": postEditingCategories,
+                    "taskId": taskId,
+                },
+            },
+        )
+
     def generate_costs_estimation_post_editing_general_report(
         self,
         base_rates: BaseRates,

--- a/crowdin_api/api_resources/reports/resource.py
+++ b/crowdin_api/api_resources/reports/resource.py
@@ -160,7 +160,7 @@ class BaseReportsResource(BaseResource):
             },
         )
 
-    def generate_pre_translate_efficiency_general_report(
+    def generate_pre_translate_accuracy_general_report(
         self,
         projectId: Optional[int] = None,
         unit: Optional[Unit] = None,
@@ -185,7 +185,7 @@ class BaseReportsResource(BaseResource):
         return self.generate_report(
             projectId=projectId,
             request_data={
-                "name": "pre-translate-efficiency",
+                "name": "pre-translate-accuracy",
                 "schema": {
                     "unit": unit,
                     "format": format,
@@ -197,7 +197,7 @@ class BaseReportsResource(BaseResource):
             },
         )
 
-    def generate_pre_translate_efficiency_by_task_report(
+    def generate_pre_translate_accuracy_by_task_report(
         self,
         projectId: Optional[int] = None,
         unit: Optional[Unit] = None,
@@ -220,7 +220,7 @@ class BaseReportsResource(BaseResource):
         return self.generate_report(
             projectId=projectId,
             request_data={
-                "name": "pre-translate-efficiency",
+                "name": "pre-translate-accuracy",
                 "schema": {
                     "unit": unit,
                     "format": format,

--- a/crowdin_api/api_resources/reports/tests/test_reports_resources.py
+++ b/crowdin_api/api_resources/reports/tests/test_reports_resources.py
@@ -639,6 +639,122 @@ class TestReportsResource:
             (
                 {
                     "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "postEditingCategories": ["0-20", "20-50"],
+                    "languageId": "uk",
+                    "dateFrom": datetime(year=1988, month=1, day=4),
+                    "dateTo": datetime(year=2015, month=10, day=13),
+                },
+                {
+                    "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "postEditingCategories": ["0-20", "20-50"],
+                    "languageId": "uk",
+                    "dateFrom": datetime(year=1988, month=1, day=4),
+                    "dateTo": datetime(year=2015, month=10, day=13),
+                },
+            ),
+            (
+                {
+                    "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "languageId": "uk",
+                    "dateFrom": datetime(year=1988, month=1, day=4),
+                    "dateTo": datetime(year=2015, month=10, day=13),
+                },
+                {
+                    "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "postEditingCategories": None,
+                    "languageId": "uk",
+                    "dateFrom": datetime(year=1988, month=1, day=4),
+                    "dateTo": datetime(year=2015, month=10, day=13),
+                },
+            )
+        ],
+    )
+    @mock.patch("crowdin_api.api_resources.reports.resource.ReportsResource.generate_report")
+    def test_generate_pre_translate_efficiency_general_report(
+        self, m_generate_report, in_params, schema, base_absolut_url
+    ):
+        m_generate_report.return_value = "response"
+
+        resource = self.get_resource(base_absolut_url)
+        assert (
+            resource.generate_pre_translate_efficiency_general_report(
+                projectId=1,
+                **in_params
+            ) == "response"
+        )
+        m_generate_report.assert_called_once_with(
+            projectId=1,
+            request_data={
+                "name": "pre-translate-efficiency",
+                "schema": schema
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "in_params, schema",
+        [
+            (
+                {
+                    "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "postEditingCategories": ["0-20", "20-50"],
+                    "taskId": 1
+                },
+                {
+                    "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "postEditingCategories": ["0-20", "20-50"],
+                    "taskId": 1
+                }
+            ),
+            (
+                {
+                    "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "taskId": 1
+                },
+                {
+                    "unit": Unit.WORDS,
+                    "format": Format.XLSX,
+                    "postEditingCategories": None,
+                    "taskId": 1
+                }
+            )
+        ]
+    )
+    @mock.patch(
+        "crowdin_api.api_resources.reports.resource.ReportsResource.generate_report"
+    )
+    def test_generate_pre_translate_efficiency_by_task_report(
+        self, m_generate_report, in_params, schema, base_absolut_url
+    ):
+        m_generate_report.return_value = "response"
+
+        resource = self.get_resource(base_absolut_url)
+        assert (
+            resource.generate_pre_translate_efficiency_by_task_report(
+                projectId=1,
+                **in_params
+            ) == "response"
+        )
+        m_generate_report.assert_called_once_with(
+            projectId=1,
+            request_data={
+                "name": "pre-translate-efficiency",
+                "schema": schema
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "in_params, schema",
+        [
+            (
+                {
+                    "unit": Unit.WORDS,
                     "currency": Currency.UAH,
                     "format": Format.XLSX,
                     "base_rates": BaseRates(fullTranslation=0, proofread=0),

--- a/crowdin_api/api_resources/reports/tests/test_reports_resources.py
+++ b/crowdin_api/api_resources/reports/tests/test_reports_resources.py
@@ -674,14 +674,14 @@ class TestReportsResource:
         ],
     )
     @mock.patch("crowdin_api.api_resources.reports.resource.ReportsResource.generate_report")
-    def test_generate_pre_translate_efficiency_general_report(
+    def test_generate_pre_translate_accuracy_general_report(
         self, m_generate_report, in_params, schema, base_absolut_url
     ):
         m_generate_report.return_value = "response"
 
         resource = self.get_resource(base_absolut_url)
         assert (
-            resource.generate_pre_translate_efficiency_general_report(
+            resource.generate_pre_translate_accuracy_general_report(
                 projectId=1,
                 **in_params
             ) == "response"
@@ -689,7 +689,7 @@ class TestReportsResource:
         m_generate_report.assert_called_once_with(
             projectId=1,
             request_data={
-                "name": "pre-translate-efficiency",
+                "name": "pre-translate-accuracy",
                 "schema": schema
             }
         )
@@ -729,14 +729,14 @@ class TestReportsResource:
     @mock.patch(
         "crowdin_api.api_resources.reports.resource.ReportsResource.generate_report"
     )
-    def test_generate_pre_translate_efficiency_by_task_report(
+    def test_generate_pre_translate_accuracy_by_task_report(
         self, m_generate_report, in_params, schema, base_absolut_url
     ):
         m_generate_report.return_value = "response"
 
         resource = self.get_resource(base_absolut_url)
         assert (
-            resource.generate_pre_translate_efficiency_by_task_report(
+            resource.generate_pre_translate_accuracy_by_task_report(
                 projectId=1,
                 **in_params
             ) == "response"
@@ -744,7 +744,7 @@ class TestReportsResource:
         m_generate_report.assert_called_once_with(
             projectId=1,
             request_data={
-                "name": "pre-translate-efficiency",
+                "name": "pre-translate-accuracy",
                 "schema": schema
             }
         )


### PR DESCRIPTION
This PR adds support for the new Pre-Translate Efficiency Report. More information about this Report type can be found in the [API documentation](https://support.crowdin.com/developer/api/v2/#tag/Reports/operation/api.projects.reports.post).

Closes #168