### PR TITLE
feat(api): Add croql parameter support to List Terms API

### DIFF
--- a/crowdin_api/api_resources/glossaries/resource.py
+++ b/crowdin_api/api_resources/glossaries/resource.py
@@ -242,6 +242,7 @@ class GlossariesResource(BaseResource):
         userId: Optional[int] = None,
         languageId: Optional[str] = None,
         conceptId: Optional[int] = None,
+        croql: Optional[str] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
     ):
@@ -256,6 +257,7 @@ class GlossariesResource(BaseResource):
             "userId": userId,
             "languageId": languageId,
             "conceptId": conceptId,
+            "croql": croql,
         }
 
         params.update(self.get_page_params(offset=offset, limit=limit))

--- a/crowdin_api/api_resources/glossaries/tests/test_glossaries_resources.py
+++ b/crowdin_api/api_resources/glossaries/tests/test_glossaries_resources.py
@@ -272,6 +272,7 @@ class TestGlossariesResource:
                     "userId": None,
                     "languageId": None,
                     "conceptId": None,
+                    "croql": None,
                     "offset": 0,
                     "limit": 25,
                 },
@@ -281,11 +282,13 @@ class TestGlossariesResource:
                     "userId": 1,
                     "languageId": "ua",
                     "conceptId": 2,
+                    "croql": "status = 'preferred'",
                 },
                 {
                     "userId": 1,
                     "languageId": "ua",
                     "conceptId": 2,
+                    "croql": "status = 'preferred'",
                     "offset": 0,
                     "limit": 25,
                 },
@@ -295,7 +298,6 @@ class TestGlossariesResource:
     @mock.patch("crowdin_api.requester.APIRequester.request")
     def test_list_terms(self, m_request, incoming_data, request_params, base_absolut_url):
         m_request.return_value = "response"
-
         resource = self.get_resource(base_absolut_url)
         assert resource.list_terms(glossaryId=1, **incoming_data) == "response"
         m_request.assert_called_once_with(


### PR DESCRIPTION
Added support for filtering terms using CroQL query parameter in the List Terms API endpoint.

Changes:
- Added croql parameter to list_terms method
- Updated test suite with new test cases for CroQL filtering
- Maintained compatibility with existing query parameters

Closes #182