### PR TITLE
feat: Add support for acceptSourceChanges in string-based MergeBranch API

### DIFF
--- a/crowdin_api/api_resources/branches/types.py
+++ b/crowdin_api/api_resources/branches/types.py
@@ -24,3 +24,4 @@ class MergeBranchRequest(TypedDict):
     deleteAfterMerge: Optional[bool]
     sourceBranchId: int
     dryRun: Optional[bool]
+    acceptSourceChanges: bool


### PR DESCRIPTION
This PR adds the optional acceptSourceChanges parameter to the MergeBranchRequest TypedDict for the string-based API. Resolves #217