### PR TITLE
chore: remove redundant black pin from dev requirements

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 
-black==23.3.0
 pre-commit==3.4.0
 xenon==0.9.1
 doc8==1.1.1


### PR DESCRIPTION
black is supplied by pre-commit via black-pre-commit-mirror in its own isolated environment, so the requirements-dev.txt pin was unused by CI (which runs only flake8 and pytest) and disagreed with the hook rev (23.3.0 vs 23.9.1). Removing it also clears two FOSSA findings against black 23.3.0, neither of which applies here: CVE-2026-31900 affects the psf/black GitHub Action (not used in this repo) and CVE-2026-32274 was introduced in 24.3.0. Bumping the pin instead is not an option, since black >= 25.12.0 requires Python 3.10+ while CI installs these requirements on 3.8 and 3.9.